### PR TITLE
fix: broken extension

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,10 +1,10 @@
-document.addEventListener('DOMContentLoaded', function() {
-  const submitButton = document.querySelector('button[data-e2e-locator="console-submit-button"]'); 
+setTimeout(() => {
+  const submitButton = document.querySelector('button[data-e2e-locator="console-submit-button"]');
   if (submitButton) {
     submitButton.addEventListener('click', () => {
       // Send message to background.js indicating that the submit button was clicked
       chrome.runtime.sendMessage({ action: "submitButtonClicked" });
-      
+
       // Check for changes in the submission result
       const observer = new MutationObserver((mutationsList, observer) => {
         mutationsList.forEach(mutation => {
@@ -24,14 +24,16 @@ document.addEventListener('DOMContentLoaded', function() {
       observer.observe(document.body, { subtree: true, childList: true });
     });
   }
-});
+}, 1000)
+
+
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "codeAccepted") {
-   chrome.tabs.executeScript({
+    chrome.tabs.executeScript({
       file: 'background.js'
     });
- }
+  }
 });
 
 


### PR DESCRIPTION
- You don't need to look for `DOMContentLoaded` listener because by default the script will load after the dom content has loaded based on default value of `run_at` property in manifest.json which is `document_idle`.
- You also need to defer the DOM access/manipulation code in the content file either by `setTimeout/setInterval/mutation observer` because the dom might not be updated after load event, i have wrapped the code below with setTimeout you can run it and check once.